### PR TITLE
Describe library in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
-# Rspec::CollectionMatchers
+# RSpec::CollectionMatchers [![Build Status](https://secure.travis-ci.org/rspec/rspec-collection_matchers.png?branch=master)](http://travis-ci.org/rspec/rspec-collection_matchers)
 
-TODO: Write a gem description
+RSpec::CollectionMatchers lets you express expected outcomes on collections
+of an object in an example.
 
-## Installation
+    expect(account.shopping_cart).to have_exactly(3).items
+
+## Install
 
 Add this line to your application's Gemfile:
 
@@ -16,14 +19,49 @@ Or install it yourself as:
 
     $ gem install rspec-collection_matchers
 
-## Usage
+## Basic usage
 
-TODO: Write usage instructions here
+Using `rspec-collection_matchers` you can match the number of items in a
+collection directly, e.g.:
 
-## Contributing
+```ruby
+it 'matches number of items in a collection' do
+  expect([1,2,3]).to have_at_least(3).items
+end
+```
 
-1. Fork it
-2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Commit your changes (`git commit -am 'Add some feature'`)
-4. Push to the branch (`git push origin my-new-feature`)
-5. Create new Pull Request
+You can also match the number of items returned by a method on an object, e.g.:
+
+```ruby
+class Cart
+  def initialize(*products)
+    @products = products
+  end
+  attr_reader :products
+end
+
+it 'matches number of items returned from a method' do
+  cart = Cart.new('product a', 'product b')
+  expect(cart).to have_at_most(2).products
+end
+```
+
+The last line of the example expresses an expected outcome:
+if `cart.products.size <= 2` then the example passes, otherwise it fails with a message like:
+
+    expected at most 2 products, got 3
+
+## Available matchers
+
+```ruby
+expect(collection).to have(n).items
+expect(collection).to have_exactly(n).items
+expect(collection).to have_at_most(n).items
+expect(collection).to have_at_least(n).items
+```
+
+## See also
+
+* [http://github.com/rspec/rspec](http://github.com/rspec/rspec)
+* [http://github.com/rspec/rspec-core](http://github.com/rspec/rspec-core)
+* [http://github.com/rspec/rspec-expectations](http://github.com/rspec/rspec-expectations)


### PR DESCRIPTION
The previous README was only a scaffold.
The current README describes the matches made available by this library, following the structure of [rspec-expectation's README](https://github.com/rspec/rspec-expectations/blob/master/README.md)
