### PR TITLE
Add config info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Or install it yourself as:
 
     $ gem install rspec-collection_matchers
 
-
 ## Basic usage
 
 First of all, you need to require rspec-collection matchers. Add the following line to your `spec_helper.rb`:


### PR DESCRIPTION
The current README doesn't mention that it's needed to require `rspec/collection_matchers` to use it. That PR solves that problem.
