### PR TITLE
Add matcher aliases for composability

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 ### Development
 
+Enhancements:
+
+* Add an `have` matcher alias `a_collection_having` (Hugo Baraúna, #25)
+
 Bug Fixes:
 
 * Define `to_ary` on Ruby 1.9.2 to fix issue when diffing in compound expectations

--- a/lib/rspec/collection_matchers/matchers.rb
+++ b/lib/rspec/collection_matchers/matchers.rb
@@ -34,7 +34,7 @@ module RSpec
       RSpec::CollectionMatchers::Have.new(n)
     end
     alias :have_exactly :have
-    alias_matcher :a_collection_having, :have
+    alias :a_collection_having :have
 
     # Exactly like have() with >=.
     #

--- a/lib/rspec/collection_matchers/matchers.rb
+++ b/lib/rspec/collection_matchers/matchers.rb
@@ -34,6 +34,7 @@ module RSpec
       RSpec::CollectionMatchers::Have.new(n)
     end
     alias :have_exactly :have
+    alias_matcher :a_collection_having, :have
 
     # Exactly like have() with >=.
     #

--- a/spec/rspec/collection_matchers/have_spec.rb
+++ b/spec/rspec/collection_matchers/have_spec.rb
@@ -428,6 +428,21 @@ EOF
         expect([1, 2, 3]).to be_truthy.or have(3).items
       end
     end
+
+    context "using the have matcher as an argument of another matcher" do
+      it "has an alias for the have matcher" do
+        word = "hi"
+
+        expect {
+          word = "hey"
+        }.to change { word }.
+          from( a_collection_having(2).letters ).
+          to( a_collection_having(3).letters )
+      end
+
+      it "has an alias for the have_at_most matcher"
+      it "has an alias for the have_at_least matcher"
+    end
   end
 
   describe RSpec::CollectionMatchers::Have, "for a collection owner that implements #send" do


### PR DESCRIPTION
Related to #23 

Add alias for the have matchers, so that one can write:

``` ruby
expect { |probe|
  foo.bar(&probe)
}.to yield_with_args( a_collection_having(3).items )
```

Instead of:

``` ruby
expect { |probe|
  foo.bar(&probe)
}.to yield_with_args( have(3).items )
```
