### PR TITLE
Use pre-1.9.3 friendly version of i18n

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,8 +15,9 @@ end
 # only the master branch is supported on rspec-support
 gem "rspec-support", :git => "git://github.com/rspec/rspec-support.git"
 
-gem "cucumber", "~> 1.1.9"
 gem "aruba",    "~> 0.5"
+gem "cucumber", "~> 1.1.9"
+gem "i18n",     "~> 0.6.11" if RUBY_VERSION < '1.9.3'
 gem "rake",     "~> 10.0.0"
 
 version_file = File.expand_path("../.rails-version", __FILE__)
@@ -38,7 +39,6 @@ end
 
 gem "activesupport", *rails_gem_args
 gem "activemodel",   *rails_gem_args
-
 
 platform :rbx do
   gem 'rubysl'


### PR DESCRIPTION
:information_desk_person: The trunk version of the `i18n` gem (~> 0.7.0) only supports Ruby >= 1.9.3, which has resulted in a series of broken builds. These changes add a conditional for legacy versions of Ruby so that this gem can be installed.
