### PR TITLE
Compound matchers for collections with send implementation

### DIFF
--- a/spec/rspec/collection_matchers/have_spec.rb
+++ b/spec/rspec/collection_matchers/have_spec.rb
@@ -428,6 +428,58 @@ EOF
         expect([1, 2, 3]).to be_truthy.or have(3).items
       end
     end
+
+    describe "for a collection owner that implements #send" do
+      before(:each) do
+        @collection = Object.new
+        def @collection.floozles; [1,2,3] end
+        def @collection.send; :sent; end
+      end
+
+      context "using #and" do
+        it "fails with relevant error when only first expectation fails" do
+          expect {
+            expect(@collection).to be_falsey.and have(3).floozles
+          }.to fail_matching "expected: falsey value"
+        end
+
+        it "fails with relevant error when only second expectation fails" do
+          expect {
+            expect(@collection).to have(3).floozles.and be_falsey
+          }.to fail_matching "expected: falsey value"
+        end
+
+        it "fails with relevant error when both expectations fail" do
+          expect {
+            expect(@collection).to be_falsey.and have(0).floozles
+          }.to fail_matching "...and:"
+        end
+
+        it "passes when both expectations are met" do
+          expect(@collection).to have(3).floozles.and be_truthy
+        end
+      end
+
+      context "using #or" do
+        it "fails with relevant error when neither expectation is met" do
+          expect {
+            expect([1, 2, 3]).to be_falsey.or have(0).floozles
+          }.to fail_with(/expected: falsey.*or.*0 floozles/m)
+        end
+
+        it "passes when only first expectation is met" do
+          expect([1, 2, 3]).to have(3).floozles.or be_falsey
+        end
+
+        it "passes when only second expectation is met" do
+          expect([1, 2, 3]).to be_falsey.or have(3).floozles
+        end
+
+        it "passes when both expectations are met" do
+          expect([1, 2, 3]).to be_truthy.or have(3).floozles
+        end
+      end
+    end
   end
 
   describe RSpec::CollectionMatchers::Have, "for a collection owner that implements #send" do


### PR DESCRIPTION
This PR adds (failing) specs addressing compound matchers with collections using the #send implementation:

``` ruby
expect(@collection).to have(3).floozles.and be_truthy
```

```
  1) have matcher expectations compounded with RSpec::Matchers::Composable for a collection owner that implements #send using #and passes when both expectations are met
     Failure/Error: collection_or_owner.__send__(@collection_name, *@args, &@block)

     NoMethodError:
       undefined method `supports_block_expectations?' for #<Object:0x00000002a38c50>
     # ./lib/rspec/collection_matchers/have.rb:58:in `determine_collection'
     # ./lib/rspec/collection_matchers/have.rb:28:in `matches?'
     # ./spec/rspec/collection_matchers/have_spec.rb:459:in `block (5 levels) in <top (required)>'
```

The following is a dirty workaround to let the tests pass. Unfortunately I am not into rspec internals that I could add a real fix.

``` diff
diff --git a/lib/rspec/collection_matchers/have.rb b/lib/rspec/collection_matchers/have.rb
index 57d70f5..22aa9f7 100644
--- a/lib/rspec/collection_matchers/have.rb
+++ b/lib/rspec/collection_matchers/have.rb
@@ -112,6 +112,7 @@ EOF
       private

       def method_missing(method, *args, &block)
+        return super if /\?$/ =~ method
         @collection_name = method
         if inflector = (defined?(ActiveSupport::Inflector) && ActiveSupport::Inflector.respond_to?(:pluralize) ? ActiveSupport::Inflector : (defined?(Inflector) ? Inflector : nil))
           @plural_collection_name = inflector.pluralize(method.to_s)

```
