### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/rspec-collection_matchers.gemspec
+++ b/rspec-collection_matchers.gemspec
@@ -13,6 +13,14 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/rspec/rspec-collection_matchers"
   spec.license       = "MIT"
 
+  spec.metadata = {
+    'bug_tracker_uri'   => 'https://github.com/rspec/rspec-collection_matchers/issues',
+    'changelog_uri'     => "https://github.com/rspec/rspec-collection_matchers/blob/v#{spec.version}/Changelog.md",
+    'documentation_uri' => 'https://rspec.info/documentation/',
+    'mailing_list_uri'  => 'https://groups.google.com/forum/#!forum/rspec',
+    'source_code_uri'   => 'https://github.com/rspec/rspec-collection_matchers',
+  }
+
   spec.files         = `git ls-files`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(spec|features)/})


### PR DESCRIPTION
Following on from rspec/rspec-core#2574.

Add [project metadata](https://guides.rubygems.org/specification-reference/#metadata) to the gemspec file. This'll allow people to more easily access the source code, raise issues and read the changelog. These `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, `mailing_list_uri` and `source_code_uri` links will appear or replace those on the rubygems page at https://rubygems.org/gems/rspec-collection_matchers after the next release.