### PR TITLE
CI: Use 2.4.6, 2.5.5, 2.6.2, allow Bundler 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: ruby
 script: "script/test_all"
 bundler_args: "--standalone --binstubs --without documentation"
-sudo: false
 before_install:
-  - gem update --system
-  - gem install bundler
+  - gem update --system --conservative || (gem i "rubygems-update:~>2.7" --no-document && update_rubygems)
+  - gem update bundler --conservative
+
 rvm:
   - 1.8.7
   - 1.9.2
@@ -13,8 +13,9 @@ rvm:
   - 2.1
   - 2.2.10
   - 2.3.8
-  - 2.4.5
-  - 2.5.3
+  - 2.4.6
+  - 2.5.5
+  - 2.6.2
   - ree
   - jruby-19mode
   - jruby-18mode

--- a/rspec-collection_matchers.gemspec
+++ b/rspec-collection_matchers.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency     "rspec-expectations", ">= 2.99.0.beta1"
 
-  spec.add_development_dependency "bundler",     "~> 1.3"
+  spec.add_development_dependency "bundler",     ">= 1.3"
   spec.add_development_dependency "activemodel", ">= 3.0"
 end


### PR DESCRIPTION
This PR updates the CI matrix to use latest patch releases.

  - Drop sudo: false - Removes an old setting from Travis. See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration