### PR TITLE
Add have(:no) to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ expect(collection).to have(n).items
 expect(collection).to have_exactly(n).items
 expect(collection).to have_at_most(n).items
 expect(collection).to have_at_least(n).items
+expect(collection).to have(:no).items
 ```
 
 ## See also


### PR DESCRIPTION
Hello :)

I was searching today for a natural way to express the expectation of an empty Rails association.

First I wrote this, hoping it would work:

```ruby
expect(bird).not_to have.feathers
```

This did not work :)

I dived into the source and discovered that I could do this:

```
expect(bird).to have(:no).feathers
```

This is also a good way to make the expectation sould like natural English :)

So I thought that it's worth mentioning in the README.