### PR TITLE
Fix for NoMethodError: undefined method `supports_value_expectations?'

### DIFF
--- a/lib/rspec/collection_matchers/have.rb
+++ b/lib/rspec/collection_matchers/have.rb
@@ -116,6 +116,10 @@ EOF
         "have #{relative_expectation} #{@collection_name}"
       end
 
+      def supports_value_expectations?
+        true
+      end
+
       def respond_to?(m, include_all = false)
         @expected.respond_to?(m, include_all) || super
       end


### PR DESCRIPTION
In order to upgrade an application to Rails 6.1, it is necessary to use newer version of `rspec-rails` 4.1.0.pre, which requires rspec-expectations 3.11.0.pre.

Turns out that rspec-expectations 3.11.0.pre is incompatible with current rspec-collection_matchers, because of [this change](https://github.com/rspec/rspec-expectations/pull/1139), a call to `expect(my_object).to have(...)` is raising a `NoMethodError: undefined method 'supports_value_expectations?' for <MyObject:0x000055a1b6e065c0>`. 

This is because `Spec::Expectations::ExpectationTarget` calls `matcher.supports_value_expectation` [here](https://github.com/rspec/rspec-expectations/blob/4e7011fe8ac68b74621336b07f894879c8da202d/lib/rspec/expectations/expectation_target.rb#L127).

Which ends up being processed by `Have#method_missing` which sets `supports_value_expectations?` to `@collection_name`. Then, later in `Have#determine_collection` it tries to call `supports_value_expectations?` on `my_object`, which causes the `NoMethodError`.

The fix is simple, just implement `Have#supports_value_expectations?`.