### PR TITLE
Exclude spec files from gem package

### DIFF
--- a/rspec-collection_matchers.gemspec
+++ b/rspec-collection_matchers.gemspec
@@ -21,7 +21,8 @@ Gem::Specification.new do |spec|
     'source_code_uri'   => 'https://github.com/rspec/rspec-collection_matchers',
   }
 
-  spec.files         = `git ls-files`.split($/)
+  spec.files         = `git ls-files -- lib/*`.split("\n")
+  spec.files         += %w[README.md LICENSE.txt Changelog.md]
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(spec|features)/})
   spec.require_paths = ["lib"]


### PR DESCRIPTION
Here's a patch that excludes files under spec directory from the gem package. The code is taken from [rspec-core's gemspec](https://github.com/rspec/rspec-core/blob/2ba0f10fe68948e5ee9addd569b4694f0245aa71/rspec-core.gemspec#L24-L25), and edited a little bit.

With this patch, the gem package size shrinks as follows:
```
before: 17920 bytes
after:  9216 bytes
```